### PR TITLE
3 aggregator

### DIFF
--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -22,9 +22,16 @@
 
         <dependency>
             <groupId>ru.yandex.practicum</groupId>
-            <artifactId>avro-schemas</artifactId>
+            <artifactId>proto-schemas</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>net.devh</groupId>
+            <artifactId>grpc-server-spring-boot-starter</artifactId>
+            <version>3.1.0.RELEASE</version>
+        </dependency>
+
 
         <dependency>
             <groupId>jakarta.validation</groupId>

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/kafka/telemetry/controller/EventController.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/kafka/telemetry/controller/EventController.java
@@ -1,0 +1,28 @@
+package ru.yandex.practicum.kafka.telemetry.controller;
+
+import com.google.protobuf.Empty;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import ru.yandex.practicum.grpc.telemetry.collector.CollectorControllerGrpc;
+import ru.yandex.practicum.grpc.telemetry.event.SensorEventProto;
+
+public class EventController extends CollectorControllerGrpc.CollectorControllerImplBase {
+
+    @Override
+    public void collectSensorEvent(SensorEventProto request, StreamObserver<Empty> responseObserver) {
+        try {
+            // здесь реализуется бизнес-логика
+            // ...
+
+            responseObserver.onNext(Empty.getDefaultInstance());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(new StatusRuntimeException(
+                    Status.INTERNAL
+                            .withDescription(e.getLocalizedMessage())
+                            .withCause(e)
+            ));
+        }
+    }
+}

--- a/telemetry/serialization/proto-schemas/pom.xml
+++ b/telemetry/serialization/proto-schemas/pom.xml
@@ -45,7 +45,6 @@
 
                 <configuration>
                     <protocVersion>${protobuf.version}</protocVersion>
-
                     <binaryMavenPlugins>
                         <binaryMavenPlugin>
                             <groupId>io.grpc</groupId>

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/hub_event.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/hub_event.proto
@@ -1,0 +1,86 @@
+syntax = "proto3";
+
+package telemetry.message;
+
+option java_multiple_files = true;
+option java_package = "ru.yandex.practicum.grpc.telemetry.event";
+
+import "google/protobuf/timestamp.proto";
+
+message HubEventProto {
+  string hub_id = 1; // идентификатор хаба
+  google.protobuf.Timestamp timestamp = 2; // таймстемп события
+  oneof payload {// содержимое конкретного события
+    DeviceAddedEventProto device_added = 3;      // данные события добавления устройства
+    DeviceRemovedEventProto device_removed = 4;  // данные события удаления устройства
+    ScenarioAddedEventProto scenario_added = 5;      // данные события добавления нового сценария
+    ScenarioRemovedEventProto scenario_removed = 6;  // данные события удаления сценария
+  }
+}
+
+// события (де)регистрации устройств
+enum DeviceTypeProto {
+  MOTION_SENSOR = 0;      // датчик движения
+  TEMPERATURE_SENSOR = 1; // датчик температуры
+  LIGHT_SENSOR = 2;       // датчик освещённости
+  CLIMATE_SENSOR = 3;     // датчик контроля климата
+  SWITCH_SENSOR = 4;      // переключатель
+}
+
+message DeviceAddedEventProto {
+  string id = 1;        // идентификатор устройства
+  DeviceTypeProto type = 2; // тип устройства
+}
+
+message DeviceRemovedEventProto {
+  string id = 1;        // идентификатор устройства
+}
+
+// события создания/удаления сценариев
+enum ConditionTypeProto {
+  MOTION = 0;
+  LUMINOSITY = 1;
+  SWITCH = 2;
+  TEMPERATURE = 3;
+  CO2LEVEL = 4;
+  HUMIDITY = 5;
+}
+
+enum ConditionOperationProto {
+  EQUALS = 0;
+  GREATER_THAN = 1;
+  LOWER_THAN = 2;
+}
+
+message ScenarioConditionProto {
+  string sensor_id = 1;
+  ConditionTypeProto type = 2;
+  ConditionOperationProto operation = 3;
+  oneof value {
+    bool bool_value = 4;
+    int32 int_value = 5;
+  }
+}
+
+enum ActionTypeProto {
+  ACTIVATE = 0;
+  DEACTIVATE = 1;
+  INVERSE = 2;
+  SET_VALUE = 3;
+}
+
+message DeviceActionProto {
+  string sensor_id = 1; // идентификатор устройства
+  ActionTypeProto type = 2;
+  optional int32 value = 3;
+}
+
+message ScenarioAddedEventProto {
+  string name = 1; // название сценария, уникальное в рамках хаба
+  repeated ScenarioConditionProto condition = 2; // набор условий активации сценария
+  repeated DeviceActionProto action = 3; // набор действий при активации сценария
+}
+message ScenarioRemovedEventProto {
+  string name = 1; // название сценария, уникальное в рамках хаба
+}
+

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/sensor_event.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/sensor_event.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package telemetry.message;
+
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_package = "ru.yandex.practicum.grpc.telemetry.event";
+
+message SensorEventProto {
+  string id = 1; // идентификатор датчика
+  google.protobuf.Timestamp timestamp = 2; // таймстемп события
+  string hub_id = 3; // идентификатор связанного хаба
+  oneof payload {// данные события от конкретного устройства
+    MotionSensorEvent motion_sensor_event = 4;            // данные события датчика движения
+    TemperatureSensorEvent temperature_sensor_event = 5;  // данные события температурного датчика
+    LightSensorEvent light_sensor_event = 6;              // данные события датчика освещённости
+    ClimateSensorEvent climate_sensor_event = 7;          // данные события климатического датчика
+    SwitchSensorEvent switch_sensor_event = 8;            // данные события датчика-переключателя
+  }
+}
+
+message MotionSensorEvent {
+  int32 link_quality = 1; // показатель качества связи; чем выше значение, тем лучше качество связи
+  bool motion = 2;        // указание на наличие движения или чьего-то присутствия
+  int32 voltage = 3;      // значение напряжения, которое может использоваться для оценки текущего напряжения в сенсоре или связанном устройстве
+}
+
+message TemperatureSensorEvent {
+  int32 temperature_c = 1; // уровень температуры по шкале Цельсия
+  int32 temperature_f = 2; // уровень температуры по Фаренгейту
+}
+
+message LightSensorEvent {
+  int32 link_quality = 1; // уровень сигнала
+  int32 luminosity = 2;   // уровень освещённости
+}
+
+message ClimateSensorEvent {
+  int32 temperature_c = 1;  // уровень температуры по шкале Цельсия
+  int32 humidity = 2;       // влажность
+  int32 co2_level = 3;      // уровень CO2
+}
+
+
+message SwitchSensorEvent {
+  bool state = 1; // состояние переключателя: включён/выключен
+}

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/sensor_event.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/message/sensor_event.proto
@@ -2,47 +2,46 @@ syntax = "proto3";
 
 package telemetry.message;
 
-import "google/protobuf/timestamp.proto";
-
 option java_multiple_files = true;
 option java_package = "ru.yandex.practicum.grpc.telemetry.event";
+
+import "google/protobuf/timestamp.proto";
 
 message SensorEventProto {
   string id = 1; // идентификатор датчика
   google.protobuf.Timestamp timestamp = 2; // таймстемп события
-  string hub_id = 3; // идентификатор связанного хаба
+  string hubId = 3; // идентификатор связанного хаба
   oneof payload {// данные события от конкретного устройства
-    MotionSensorEvent motion_sensor_event = 4;            // данные события датчика движения
-    TemperatureSensorEvent temperature_sensor_event = 5;  // данные события температурного датчика
-    LightSensorEvent light_sensor_event = 6;              // данные события датчика освещённости
-    ClimateSensorEvent climate_sensor_event = 7;          // данные события климатического датчика
-    SwitchSensorEvent switch_sensor_event = 8;            // данные события датчика-переключателя
+    MotionSensorProto motion_sensor_event = 4;            // данные события датчика движения
+    TemperatureSensorProto temperature_sensor_event = 5;  // данные события температурного датчика
+    LightSensorProto light_sensor_event = 6;              // данные события датчика освещённости
+    ClimateSensorProto climate_sensor_event = 7;          // данные события климатического датчика
+    SwitchSensorProto switch_sensor_event = 8;            // данные события датчика-переключателя
   }
 }
 
-message MotionSensorEvent {
+message MotionSensorProto {
   int32 link_quality = 1; // показатель качества связи; чем выше значение, тем лучше качество связи
   bool motion = 2;        // указание на наличие движения или чьего-то присутствия
   int32 voltage = 3;      // значение напряжения, которое может использоваться для оценки текущего напряжения в сенсоре или связанном устройстве
 }
 
-message TemperatureSensorEvent {
+message TemperatureSensorProto {
   int32 temperature_c = 1; // уровень температуры по шкале Цельсия
   int32 temperature_f = 2; // уровень температуры по Фаренгейту
 }
 
-message LightSensorEvent {
+message LightSensorProto {
   int32 link_quality = 1; // уровень сигнала
   int32 luminosity = 2;   // уровень освещённости
 }
 
-message ClimateSensorEvent {
+message ClimateSensorProto {
   int32 temperature_c = 1;  // уровень температуры по шкале Цельсия
   int32 humidity = 2;       // влажность
   int32 co2_level = 3;      // уровень CO2
 }
 
-
-message SwitchSensorEvent {
+message SwitchSensorProto {
   bool state = 1; // состояние переключателя: включён/выключен
 }

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/messages/hub_event.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/messages/hub_event.proto
@@ -1,6 +1,0 @@
-syntax = "proto3";
-
-package telemetry.message.event;
-
-option java_multiple_files = true;
-option java_package = "ru.yandex.practicum.grpc.telemetry.event";

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/messages/sensor_event.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/messages/sensor_event.proto
@@ -1,6 +1,0 @@
-syntax = "proto3";
-
-package telemetry.message.event;
-
-option java_multiple_files = true;
-option java_package = "ru.yandex.practicum.grpc.telemetry.event";

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/service/collector_controller.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/service/collector_controller.proto
@@ -1,0 +1,19 @@
+
+import "telemetry/message/sensor_event.proto";
+import "telemetry/message/hub_event.proto";
+
+package telemetry.service;
+
+option java_multiple_files = true;
+option java_package = "ru.yandex.practicum.grpc.telemetry.collector";
+
+import "google/protobuf/empty.proto";
+
+
+service CollectorController {
+  rpc CollectSensorEvent (SensorEventProto)
+      returns (google.protobuf.Empty);
+
+  rpc CollectHubEvent (HubEventProto)
+      returns (google.protobuf.Empty);
+}

--- a/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/service/collector_controller.proto
+++ b/telemetry/serialization/proto-schemas/src/main/protobuf/telemetry/service/collector_controller.proto
@@ -1,19 +1,20 @@
-
-import "telemetry/message/sensor_event.proto";
-import "telemetry/message/hub_event.proto";
+syntax = "proto3";
 
 package telemetry.service;
 
 option java_multiple_files = true;
 option java_package = "ru.yandex.practicum.grpc.telemetry.collector";
 
+import "telemetry/message/sensor_event.proto";
+import "telemetry/message/hub_event.proto";
 import "google/protobuf/empty.proto";
 
 
+
 service CollectorController {
-  rpc CollectSensorEvent (SensorEventProto)
+  rpc CollectSensorEvent (telemetry.message.SensorEventProto)
       returns (google.protobuf.Empty);
 
-  rpc CollectHubEvent (HubEventProto)
+  rpc CollectHubEvent (telemetry.message.HubEventProto)
       returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates telemetry to Protobuf/gRPC and scaffolds the collector service.
> 
> - Switches collector dependency from `avro-schemas` to `proto-schemas` and adds `grpc-server-spring-boot-starter` in `collector/pom.xml`
> - Implements `EventController` extending `CollectorControllerImplBase` with `collectSensorEvent` handling (returns `google.protobuf.Empty`)
> - Adds Protobuf message schemas: `telemetry/message/sensor_event.proto` and `telemetry/message/hub_event.proto`
> - Defines gRPC service `telemetry/service/collector_controller.proto` with `CollectSensorEvent` and `CollectHubEvent` RPCs
> - Removes old placeholder `.proto` files under `telemetry/messages`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50d070336550dc7fdeee2f034844aa6ec1aba914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->